### PR TITLE
fix: Place subtasks under correct parent

### DIFF
--- a/.todo.ai/.todo.ai.log
+++ b/.todo.ai/.todo.ai.log
@@ -2,6 +2,16 @@
 # Format: TIMESTAMP | USER | ACTION | TASK_ID | DESCRIPTION
 # Generated: Thu Oct 30 21:17:25 CET 2025
 
+2026-01-17 12:11:52 | fxstein | UPDATE_NOTE | 178 | Updated note (was 1 lines, now        1 lines)
+2026-01-17 12:11:45 | fxstein | UPDATE_NOTE | 178 | Updated note (was 1 lines, now        1 lines)
+2026-01-17 12:09:44 | fxstein | COMPLETE | 178.3 | Add tests for multiple parents/subtasks
+2026-01-17 12:09:44 | fxstein | COMPLETE | 178.2 | Fix subtask insertion to correct parent
+2026-01-17 12:09:44 | fxstein | COMPLETE | 178.1 | Investigate subtask placement logic
+2026-01-17 12:09:32 | fxstein | NOTE | 178 | Investigate/fix in todo_ai/cli/commands/__init__.py add_subtask_command; tests in tests/integration/test_cli.py (add_subtasks_multiple_parents).
+2026-01-17 12:06:02 | fxstein | ADD_SUBTASK | 178.3 | Add tests for multiple parents/subtasks (parent: #178)
+2026-01-17 12:06:01 | fxstein | ADD_SUBTASK | 178.2 | Fix subtask insertion to correct parent (parent: #178)
+2026-01-17 12:06:01 | fxstein | ADD_SUBTASK | 178.1 | Investigate subtask placement logic (parent: #178)
+2026-01-17 12:05:53 | fxstein | ADD | 178 | Fix issue#40: Subtasks assigned to wrong parent
 2025-12-17 22:46:59 | fxstein | COMPLETE | 177 | Fix release process - PyPI must succeed before GitHub release
 2025-12-17 22:07:35 | fxstein | COMPLETE | 177.1 | Update PyPI Trusted Publisher config to ci-cd.yml/release
 2025-12-17 21:52:23 | fxstein | COMPLETE | 177.3 | Move GitHub release to workflow (after PyPI success)

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,11 @@
 > **⚠️ IMPORTANT: This file should ONLY be edited through the `todo.ai` script!**
 
 ## Tasks
+- [ ] **#178** Fix issue#40: Subtasks assigned to wrong parent `#bug`
+  > Investigate/fix in `todo_ai/cli/commands/__init__.py` add_subtask_command; tests in `tests/integration/test_cli.py` (add_subtasks_multiple_parents).
+  - [x] **#178.3** Add tests for multiple parents/subtasks `#bug`
+  - [x] **#178.2** Fix subtask insertion to correct parent `#bug`
+  - [x] **#178.1** Investigate subtask placement logic `#bug`
 - [x] **#177** Fix release process - PyPI must succeed before GitHub release `#critical` `#infrastructure`
   - [x] **#177.3** Move GitHub release to workflow (after PyPI success) `#infrastructure`
   - [x] **#177.2** Remove GitHub release creation from release.sh `#infrastructure`
@@ -1062,6 +1067,6 @@
 
 ---
 
-**Last Updated:** Wed Dec 17 22:47:00 CET 2025
+**Last Updated:** Sat Jan 17 12:11:52 CET 2026
 **Repository:** https://github.com/fxstein/todo.ai
 **Maintenance:** Use `todo.ai` script only


### PR DESCRIPTION
## Summary
- insert new subtasks immediately after their parent (or last existing subtask)
- keep add-subtask ordering stable across multiple parents
- add integration test for multi-parent subtask placement

## Testing
- uv run pytest tests/integration/test_cli.py::test_add_subtasks_multiple_parents

Closes #40