### PR TITLE
fix: Correct Release Please extra-files config (task#269.3)

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -24,7 +24,7 @@
       ],
       "extra-files": [
         {
-          "type": "python",
+          "type": "generic",
           "path": "ai_todo/__init__.py",
           "glob": false
         }


### PR DESCRIPTION
## Hotfix: Release Please Configuration

**Issue:** Release Please workflow failing on main after PR #62 merge

**Error:** 

---

## Fix

Changed  type from  to  in .

**Before:**
```json
"type": "python"
```

**After:**
```json
"type": "generic"
```

**Why:** Release Please doesn't support `python` as an extra file type. The `generic` type automatically handles Python version strings like `__version__ = "4.0.0b2"`.

---

## Validation

After merge, Release Please should:
- ✅ Parse version from `ai_todo/__init__.py` correctly
- ✅ Create Release PR successfully
- ✅ Update both `pyproject.toml` and `__init__.py`

---

**Priority:** HIGH - Blocking Phase 1 testing
**Related:** #62