### PR TITLE
fix(ci): exempt Dependabot branches from branch name check (AIT-20)

### DIFF
--- a/.github/workflows/linear-pr-check.yml
+++ b/.github/workflows/linear-pr-check.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Check branch name format
         run: |
           BRANCH="${{ github.head_ref }}"
+          # Exempt automated bot branches
+          if [[ "${BRANCH}" =~ ^(dependabot|renovate|bugbot)/ ]]; then
+            echo "Bot branch '${BRANCH}' - exempt from naming convention"
+            exit 0
+          fi
           # Pattern: username/AIT-123-description (case-insensitive AIT, any username)
           if ! echo "$BRANCH" | grep -qiE '^.+\/[Aa][Ii][Tt]-[0-9]+-.+$'; then
             echo "::error::Branch must follow format username/AIT-123-description (or ait-123-description)."


### PR DESCRIPTION
## What
- Updated `.github/workflows/linear-pr-check.yml` to exempt bot branches from branch naming enforcement.
- Added an early exit for branches starting with `dependabot/`, `renovate/`, or `bugbot/`.

## Why
- Dependabot PR branches (for example `dependabot/uv/cryptography-46.0.7`) do not follow the `username/AIT-123-description` pattern.
- This causes automated dependency PRs to fail CI unnecessarily.
- This change unblocks 16 Dependabot PRs (#85–#103) while keeping naming checks for human-authored branches.

## Testing
- Verified workflow content after edit to confirm exemption is evaluated before the AIT naming regex check.
- Confirmed branch naming validation logic remains unchanged for non-bot branches.

## Refs
- AIT-20

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that relaxes branch naming enforcement for automated bot branches; could slightly reduce enforcement if a human uses the exempted prefixes.
> 
> **Overview**
> Updates the `Linear PR Check` GitHub Action to **skip branch naming validation** for automated branches starting with `dependabot/`, `renovate/`, or `bugbot/` by adding an early-exit before the AIT ticket regex check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff98d61fccd4b98d8a904acdf727ac68471beaaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->