### PR TITLE
fix(tests): replace fastmcp 2.x private API with 3.x Client API (AIT-23)

### DIFF
--- a/tests/integration/test_empty_trash_integration.py
+++ b/tests/integration/test_empty_trash_integration.py
@@ -1,10 +1,13 @@
 """Integration tests for empty trash functionality (CLI and MCP)."""
 
+import asyncio
 import io
+import json
 import sys
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from fastmcp import Client
 
 import ai_todo.mcp.server as mcp_server_module
 from ai_todo.cli.commands import (
@@ -68,14 +71,24 @@ def capture_cli_output(func, *args, **kwargs) -> str:
 
 
 def call_mcp_tool(tool_name: str, arguments: dict, todo_path: str):
-    """Call MCP tool directly."""
+    """Call MCP tool through FastMCP client API."""
     mcp_server_module.CURRENT_TODO_PATH = todo_path
 
-    tool = mcp._tool_manager._tools.get(tool_name)
-    if not tool:
-        raise ValueError(f"Unknown tool: {tool_name}")
+    async def _call():
+        async with Client(mcp) as client:
+            result = await client.call_tool(tool_name, arguments)
+            content = getattr(result, "content", result)
+            if isinstance(content, list):
+                text = "\n".join(
+                    item.text if hasattr(item, "text") else str(item) for item in content
+                )
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    return text
+            return content
 
-    return tool.fn(**arguments)
+    return asyncio.run(_call())
 
 
 def manually_set_task_expiration(todo_path: str, task_id: str, expires_days_ago: int):

--- a/tests/integration/test_mcp_cli_parity.py
+++ b/tests/integration/test_mcp_cli_parity.py
@@ -10,6 +10,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from fastmcp import Client
 
 import ai_todo.mcp.server as mcp_server_module
 from ai_todo.cli.commands import (
@@ -76,31 +77,18 @@ def capture_cli_output(func, *args, **kwargs) -> str:
 
 
 async def capture_mcp_output(tool_name: str, arguments: dict, todo_path: str) -> str:
-    """Capture MCP tool output by calling the tool directly."""
-    # Set the global TODO path in the server module
+    """Capture MCP tool output through FastMCP client API."""
     mcp_server_module.CURRENT_TODO_PATH = todo_path
 
-    # Find the tool function
-    # FastMCP stores tools in _tool_manager._tools dictionary
     try:
-        tool = mcp._tool_manager._tools.get(tool_name)
-        if tool:
-            tool_func = tool.fn
-        else:
-            tool_func = None
-    except AttributeError:
-        # Fallback if internal structure changes, try public API if available
-        # But for now we rely on internal structure for testing
-        return "Error: Could not access tool manager"
-
-    if not tool_func:
-        return f"Unknown tool: {tool_name}"
-
-    # Call the tool function with arguments
-    # We use the underlying function 'fn' to bypass FastMCP runtime overhead for unit testing
-    try:
-        result = tool.fn(**arguments)
-        return result
+        async with Client(mcp) as client:
+            result = await client.call_tool(tool_name, arguments)
+            content = getattr(result, "content", result)
+            if isinstance(content, list):
+                return "\n".join(
+                    item.text if hasattr(item, "text") else str(item) for item in content
+                )
+            return str(content)
     except Exception as e:
         return f"Error calling tool {tool_name}: {e}"
 
@@ -400,11 +388,10 @@ class TestMCPCLIParity:
 async def test_all_mcp_tools_exist():
     """Verify all expected MCP tools are registered."""
 
-    # Get registered tools from FastMCP instance
-    try:
-        tool_names = set(mcp._tool_manager._tools.keys())
-    except AttributeError:
-        pytest.fail("Could not access tools from FastMCP instance")
+    # Get registered tools via FastMCP client API
+    async with Client(mcp) as client:
+        tools = await client.list_tools()
+    tool_names = {tool.name for tool in tools}
 
     # Expected tools (all phases)
     expected_tools = {

--- a/tests/integration/test_prune_integration.py
+++ b/tests/integration/test_prune_integration.py
@@ -1,10 +1,13 @@
 """Integration tests for prune functionality (CLI and MCP)."""
 
+import asyncio
 import io
+import json
 import sys
 from pathlib import Path
 
 import pytest
+from fastmcp import Client
 
 import ai_todo.mcp.server as mcp_server_module
 from ai_todo.cli.commands import add_command, archive_command, prune_command
@@ -83,14 +86,24 @@ def capture_cli_output(func, *args, **kwargs) -> str:
 
 
 def call_mcp_tool(tool_name: str, arguments: dict, todo_path: str):
-    """Call MCP tool directly."""
+    """Call MCP tool through FastMCP client API."""
     mcp_server_module.CURRENT_TODO_PATH = todo_path
 
-    tool = mcp._tool_manager._tools.get(tool_name)
-    if not tool:
-        raise ValueError(f"Unknown tool: {tool_name}")
+    async def _call():
+        async with Client(mcp) as client:
+            result = await client.call_tool(tool_name, arguments)
+            content = getattr(result, "content", result)
+            if isinstance(content, list):
+                text = "\n".join(
+                    item.text if hasattr(item, "text") else str(item) for item in content
+                )
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    return text
+            return content
 
-    return tool.fn(**arguments)
+    return asyncio.run(_call())
 
 
 # CLI Integration Tests

--- a/tests/validation/test_complete_parity_audit.py
+++ b/tests/validation/test_complete_parity_audit.py
@@ -9,11 +9,15 @@ This test suite performs a comprehensive audit to verify that:
 This is the final gate before release (task #163.44.6).
 """
 
+import asyncio
 import re
 import subprocess
 from pathlib import Path
 
 import pytest
+from fastmcp import Client
+
+from ai_todo.mcp.server import mcp
 
 
 def get_shell_commands() -> set[str]:
@@ -149,47 +153,14 @@ def get_python_cli_commands() -> set[str]:
 
 
 def get_mcp_tools() -> set[str]:
-    """Get all MCP tool names from server definition."""
-    # The MCP tools are statically defined in server.py
-    # We know what they are from the implementation
-    return {
-        # Core Tasks
-        "add_task",
-        "add_subtask",
-        "complete_task",
-        "list_tasks",
-        "modify_task",
-        "delete_task",
-        "archive_task",
-        "restore_task",
-        "undo_task",
-        # Progress
-        "start_task",
-        "stop_task",
-        "get_active_tasks",
-        # Description & Tags (v3.1 API terminology standardization)
-        "set_description",
-        "set_tags",
-        # Display & Relationships
-        "show_task",
-        "relate_task",
-        # File Operations
-        "lint",
-        "reformat",
-        "reorder",
-        "resolve_conflicts",
-        # Configuration
-        "show_config",
-        "detect_coordination",
-        "setup_coordination",
-        "switch_mode",
-        # Tamper Detection
-        "accept_tamper",
-        # Info
-        "version",
-        "check_update",
-        "update",
-    }
+    """Get all MCP tool names from FastMCP via public client API."""
+
+    async def _list() -> set[str]:
+        async with Client(mcp) as client:
+            tools = await client.list_tools()
+            return {tool.name for tool in tools}
+
+    return asyncio.run(_list())
 
 
 class TestCompleteParity:


### PR DESCRIPTION
## What
- Replaced fastmcp 2.x private tool access (`mcp._tool_manager._tools`) in MCP integration tests with fastmcp 3.x public `Client` API.
- Updated `call_mcp_tool()` helpers to invoke tools via `Client.call_tool()` and extract/normalize returned content.
- Added JSON parsing in integration helpers for tools that now return structured payloads as text content.
- Updated MCP tool discovery in tests to use `Client.list_tools()`.

## Why
Main broke after upgrading to `fastmcp==3.2.0` because tests depended on removed private internals (`_tool_manager`). This switches tests to supported public APIs and restores compatibility.

## Testing
- `uv sync`
- `uv sync --extra dev`
- `.venv/bin/pytest tests/integration/ tests/validation/ -v`
  - Result: `101 passed`

## Refs
- AIT-23
- Fixes broken main after fastmcp 3.2.0 merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to tests and replace brittle private FastMCP internals with the supported `Client` interface; primary risk is minor output/return-shape normalization issues causing flaky assertions.
> 
> **Overview**
> Updates MCP integration/parity tests to stop reaching into FastMCP’s removed private internals (`mcp._tool_manager._tools`) and instead invoke tools via the public `fastmcp.Client` API.
> 
> Test helpers now call tools with `Client.call_tool()` (and discover them with `Client.list_tools()`), with added normalization to extract `result.content` and parse JSON-ish text payloads for tools returning structured dicts (e.g., `empty_trash`, `prune_tasks`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc863378938cf532a467f1d01dfe77b832bb7872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->