### PR TITLE
fix(ci): configure git committer for release tag creation

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,6 +45,9 @@ jobs:
             exit 1
           fi
 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           version="${tag#v}"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### What
Adds `git config user.name` and `user.email` for `github-actions[bot]` before running `git tag -a`.

### Why
The `create-release-tag` job runs on the `push` to `main` following PR #112. However, the `git tag -a` command requires a configured git committer identity, which GitHub Actions `actions/checkout` does not set by default. This caused the `create-release-tag` job to crash with `Committer identity unknown`.

### Testing
Job should cleanly execute `git tag -a` and push it to origin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow tweak that only affects GitHub Actions release tagging; main risk is misconfigured identity causing tag creation/push to fail rather than impacting runtime code.
> 
> **Overview**
> Fixes the `create-release-tag` job in `.github/workflows/ci-cd.yml` by explicitly configuring `git` `user.name` and `user.email` (as `github-actions[bot]`) before running `git tag -a`.
> 
> This prevents release automation from failing with *"Committer identity unknown"* when creating annotated tags from `main` release commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 084f7cf7620b6f2acf3e3c9eb66390df7869957f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->