### PR TITLE
fix(ci): fix release jobs skipping due to dependency skipping behavior

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -568,8 +568,10 @@ jobs:
     # CRITICAL: Only runs AFTER all tests pass
     needs: [create-release-tag, all-tests-pass]
     # Only run on tag pushes - use direct GitHub context for reliability
+    # CRITICAL: Explicitly require all-tests-pass to succeed (not just not-fail)
     if: |
       always() &&
+      needs.all-tests-pass.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       (startsWith(github.ref, 'refs/tags/v') || needs.create-release-tag.outputs.tag != '')
@@ -705,8 +707,10 @@ jobs:
     # This ensures release CANNOT proceed unless ALL tests pass
     needs: [create-release-tag, validate-release]
     # Only run on tag pushes - use same direct GitHub context as validate-release
+    # CRITICAL: Explicitly require validate-release to succeed
     if: |
       always() &&
+      needs.validate-release.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       (startsWith(github.ref, 'refs/tags/v') || needs.create-release-tag.outputs.tag != '')

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -506,8 +506,8 @@ jobs:
     name: ✅ All Tests Passed
     # Only run on tag pushes (when we need to release)
     if: |
-      always() && 
-      !contains(needs.*.result, 'failure') && 
+      always() &&
+      !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       (startsWith(github.ref, 'refs/tags/v') || needs.create-release-tag.outputs.tag != '')
     # CRITICAL: Depends on ALL test jobs
@@ -569,8 +569,8 @@ jobs:
     needs: [create-release-tag, all-tests-pass]
     # Only run on tag pushes - use direct GitHub context for reliability
     if: |
-      always() && 
-      !contains(needs.*.result, 'failure') && 
+      always() &&
+      !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       (startsWith(github.ref, 'refs/tags/v') || needs.create-release-tag.outputs.tag != '')
     runs-on: ubuntu-latest
@@ -706,8 +706,8 @@ jobs:
     needs: [create-release-tag, validate-release]
     # Only run on tag pushes - use same direct GitHub context as validate-release
     if: |
-      always() && 
-      !contains(needs.*.result, 'failure') && 
+      always() &&
+      !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       (startsWith(github.ref, 'refs/tags/v') || needs.create-release-tag.outputs.tag != '')
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -506,7 +506,7 @@ jobs:
     name: ✅ All Tests Passed
     # Only run on tag pushes (when we need to release)
     if: |
-      always() &&
+      !cancelled() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
       (startsWith(github.ref, 'refs/tags/v') || needs.create-release-tag.outputs.tag != '')
@@ -570,7 +570,7 @@ jobs:
     # Only run on tag pushes - use direct GitHub context for reliability
     # CRITICAL: Explicitly require all-tests-pass to succeed (not just not-fail)
     if: |
-      always() &&
+      !cancelled() &&
       needs.all-tests-pass.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
@@ -709,7 +709,7 @@ jobs:
     # Only run on tag pushes - use same direct GitHub context as validate-release
     # CRITICAL: Explicitly require validate-release to succeed
     if: |
-      always() &&
+      !cancelled() &&
       needs.validate-release.result == 'success' &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -505,7 +505,11 @@ jobs:
   all-tests-pass:
     name: ✅ All Tests Passed
     # Only run on tag pushes (when we need to release)
-    if: startsWith(github.ref, 'refs/tags/v') || needs.create-release-tag.outputs.tag != ''
+    if: |
+      always() && 
+      !contains(needs.*.result, 'failure') && 
+      !contains(needs.*.result, 'cancelled') &&
+      (startsWith(github.ref, 'refs/tags/v') || needs.create-release-tag.outputs.tag != '')
     # CRITICAL: Depends on ALL test jobs
     needs: [create-release-tag, docs-quality, logs-quality, quality, test-quick, test-comprehensive]
     runs-on: ubuntu-latest
@@ -564,7 +568,11 @@ jobs:
     # CRITICAL: Only runs AFTER all tests pass
     needs: [create-release-tag, all-tests-pass]
     # Only run on tag pushes - use direct GitHub context for reliability
-    if: startsWith(github.ref, 'refs/tags/v') || needs.create-release-tag.outputs.tag != ''
+    if: |
+      always() && 
+      !contains(needs.*.result, 'failure') && 
+      !contains(needs.*.result, 'cancelled') &&
+      (startsWith(github.ref, 'refs/tags/v') || needs.create-release-tag.outputs.tag != '')
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.validate.outputs.version }}
@@ -697,7 +705,11 @@ jobs:
     # This ensures release CANNOT proceed unless ALL tests pass
     needs: [create-release-tag, validate-release]
     # Only run on tag pushes - use same direct GitHub context as validate-release
-    if: startsWith(github.ref, 'refs/tags/v') || needs.create-release-tag.outputs.tag != ''
+    if: |
+      always() && 
+      !contains(needs.*.result, 'failure') && 
+      !contains(needs.*.result, 'cancelled') &&
+      (startsWith(github.ref, 'refs/tags/v') || needs.create-release-tag.outputs.tag != '')
     runs-on: ubuntu-latest
     environment: release # Required for PyPI Trusted Publisher
     permissions:


### PR DESCRIPTION
### What
Fixes an issue where the final `all-tests-pass` and `release` jobs were silently skipping during a release.

### Why
In GitHub Actions, if any job listed in a `needs` array is skipped, the dependent job is also automatically skipped unless a status check function like `always()` or `!cancelled()` is used. 
Because the `create-release-tag` job only runs on `push` (and is skipped on tag pushes), the downstream `all-tests-pass` and `release` jobs were skipping themselves since they depended on `create-release-tag`.

This patch adds `always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')` to the downstream `if` conditions, ensuring they run as long as tests succeed or skip, rather than inheriting the skip status.

### Testing
Job should cleanly execute and run the tests, and if they pass, publish the release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub Actions job `if` conditions for release gating/publishing; mistakes here could unintentionally block releases or allow releases to proceed under unexpected job states.
> 
> **Overview**
> Fixes release pipeline jobs (`all-tests-pass`, `validate-release`, `release`) being skipped due to GitHub Actions `needs` skip propagation.
> 
> Updates each job’s `if` condition to explicitly gate on *not cancelled* and no upstream failures/cancellations (and for downstream jobs, requires `all-tests-pass`/`validate-release` to be `success`), while still allowing execution on tag pushes or when `create-release-tag` outputs a tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 225542160fb0f9c7a4ed4a414bb8622aa55b5804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->