### PR TITLE
fix(release): ensure prepare_release.py outputs end with trailing newline

### DIFF
--- a/release/prepare_release.py
+++ b/release/prepare_release.py
@@ -89,6 +89,22 @@ def render_notes(version: str, commits: list[tuple[str, str]], summary_text: str
     return "\n".join(lines)
 
 
+def ensure_single_trailing_newline(text: str) -> str:
+    return text.rstrip("\n") + "\n"
+
+
+def read_summary_text(summary_file: Path) -> str:
+    if not summary_file.exists():
+        return ""
+
+    raw_summary = summary_file.read_text(encoding="utf-8")
+    normalized_summary = ensure_single_trailing_newline(raw_summary)
+    if raw_summary != normalized_summary:
+        summary_file.write_text(normalized_summary, encoding="utf-8")
+
+    return normalized_summary.strip()
+
+
 def replace_version(new_version: str) -> None:
     pyproject = ROOT / "pyproject.toml"
     init_py = ROOT / "ai_todo" / "__init__.py"
@@ -130,10 +146,10 @@ def main() -> int:
     version = next_version(last_tag, bump, args.beta)
 
     summary_file = ROOT / "release" / "AI_RELEASE_SUMMARY.md"
-    file_summary = summary_file.read_text(encoding="utf-8").strip() if summary_file.exists() else ""
+    file_summary = read_summary_text(summary_file)
     summary_text = "\n\n".join(filter(None, [args.summary.strip(), file_summary]))
 
-    notes = render_notes(version, commits, summary_text)
+    notes = ensure_single_trailing_newline(render_notes(version, commits, summary_text))
     (ROOT / "release" / "RELEASE_NOTES.md").write_text(notes, encoding="utf-8")
 
     replace_version(version)

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_prepare_release_module():
+    module_path = Path(__file__).resolve().parents[1] / "release" / "prepare_release.py"
+    spec = importlib.util.spec_from_file_location("prepare_release", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_rendered_release_notes_end_with_single_trailing_newline() -> None:
+    prepare_release = _load_prepare_release_module()
+
+    notes = prepare_release.render_notes(
+        "1.2.3",
+        [("feat: add release helper", ""), ("fix: normalize markdown output", "")],
+        "Summary paragraph.",
+    )
+    normalized = prepare_release.ensure_single_trailing_newline(notes)
+
+    assert normalized.endswith("\n")
+    assert not normalized.endswith("\n\n")
+
+
+def test_summary_file_without_trailing_newline_is_fixed(tmp_path: Path) -> None:
+    prepare_release = _load_prepare_release_module()
+
+    summary_file = tmp_path / "AI_RELEASE_SUMMARY.md"
+    summary_file.write_text("Line one\nLine two", encoding="utf-8")
+
+    summary_text = prepare_release.read_summary_text(summary_file)
+
+    assert summary_text == "Line one\nLine two"
+    assert summary_file.read_text(encoding="utf-8").endswith("\n")


### PR DESCRIPTION
## Problem

During the [v4.0.0b5 release PR (#115)](https://github.com/fxstein/ai-todo/pull/115), the `Docs Quality` CI job failed with:

```
release/AI_RELEASE_SUMMARY.md:5:151 MD047/single-trailing-newline Files should end with a single newline character
```

`release/prepare_release.py` did not enforce a trailing newline on the files it wrote (or on `AI_RELEASE_SUMMARY.md` when it was missing one), so any future release would hit the same lint failure.

## Fix

In `release/prepare_release.py`:

- Added `ensure_single_trailing_newline(text)` helper.
- Added `read_summary_text(summary_file)` that auto-fixes `release/AI_RELEASE_SUMMARY.md` on disk if it is missing a trailing newline (idempotent — does nothing if already present).
- `main()` now wraps the rendered release notes with `ensure_single_trailing_newline(...)` before writing `release/RELEASE_NOTES.md`, and uses `read_summary_text(...)` when ingesting the summary.

## Tests

Added `tests/test_prepare_release.py`:

- Rendered release notes end with exactly one trailing newline after normalization.
- An `AI_RELEASE_SUMMARY.md` missing a trailing newline is fixed after being read by prep logic.

Local verification (in the worktree):

- `ruff check .` ✅
- `ruff format --check .` ✅
- `pytest tests/test_prepare_release.py -v` ✅ (2 passed)

## Out of scope

- Tag cleanup for orphaned `v4.0.0b4` (deliberately ignored — release was completed under v4.0.0b5).

Closes AIT-26
Follow-up to PR #115

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts release-note generation/summary file normalization to satisfy markdown linting, plus adds small unit tests.
> 
> **Overview**
> Ensures the release preparation script always produces markdown files that end with **exactly one** trailing newline.
> 
> Adds `ensure_single_trailing_newline()` and `read_summary_text()` to normalize/fix `AI_RELEASE_SUMMARY.md` on read, and wraps the generated `RELEASE_NOTES.md` output with the same normalization. Adds tests covering newline normalization for rendered notes and auto-fixing a summary file missing a trailing newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3847ca307e47ca478662fa91cccf6a7c2fa23c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->